### PR TITLE
set up GitPod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: make site
+  - command: make serve

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Image Analysis Training Resources
 
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/neubias/training-resources)
+
 **[Visit the rendered pages](https://neubias.github.io/training-resources).**
 
 This project is intended to collect together various resources


### PR DESCRIPTION
Using GitPod will allow you to work with this repository without needing a working Jekyll setup on your local computer. This should make it much easier for people to contribute in future.

Clicking the GitPod button in the project README will launch a VSCode-like text editor interface directly in your browser, in an environment configured with all the dependencies for the project. You can edit files there, preview the changes to the built website, and then push your changes back to the GitHub repository when ready.

We have been happily using it on [the Building Websites with Jekyll and GitHub lesson](https://github.com/carpentries-incubator/jekyll-pages-novice) for the last few months. Let me know if you'd like a demonstration before merging.