### PR TITLE
Tiff metadata

### DIFF
--- a/_modules/tiff_metadata.md
+++ b/_modules/tiff_metadata.md
@@ -1,0 +1,39 @@
+---
+title: Template
+layout: module
+tags: ["draft"]
+prerequisites:
+  - "[TODO](../template)"
+objectives:
+  - "TODO"
+motivation: |
+  TODO
+
+concept_map: >
+  graph TD
+    T1("TODO1") --> T2("TODO2")
+    T2 --> T3("TODO3")
+
+figure: /figures/template.png
+figure_legend: TODO
+
+multiactivities:
+  - ["spatial_calibration/activities/spatial_calibration.md", [["ImageJ GUI", "spatial_calibration/activities/spatial_calibration_imagejgui.md", "markdown"], ["skimage napari", "spatial_calibration/activities/spatial_calibration_skimage_napari.py", "python"]]]
+
+assessment: >
+
+  ### Fill in the blanks
+
+    1. TODO ___ .
+    1. TODO ___ .
+    
+    > ## Solution
+    >   1. TODO
+    >   1. TODO
+    {: .solution}
+
+learn_next:
+
+external_links:
+---
+

--- a/add_new_module.sh
+++ b/add_new_module.sh
@@ -1,3 +1,3 @@
 cp -n _modules/template.md _modules/$1.md
-mkdir _includes/$1
-touch _includes/$1/activities/$1.md
+mkdir -p _includes/$1
+touch _includes/$1.md

--- a/add_new_module.sh
+++ b/add_new_module.sh
@@ -1,7 +1,3 @@
 cp -n _modules/template.md _modules/$1.md
 mkdir _includes/$1
-mkdir _includes/$1/activities
-mkdir _includes/$1/exercises
 touch _includes/$1/activities/$1.md
-touch _includes/$1/exercises/$1.md
-


### PR DESCRIPTION
@k-dominik @constantinpape @bugraoezdemir @grinic @tibuch

ping @imagejan  @joshmoore because you are always so knowledgable and helpful ❤️ 

If we like it or not, I think it is part of the job of a bioimage analysts to read and write voxel calibration metadata from some frequently occurring TIFF flavours in python.

I thus want to add a teaching module for this.

My current ideas: 

- take a commercial 3-D microscopy file (e.g. CZI) as a starting point.
    - convert this to a TIFF using
        - ImageJ > Save as
        - bioformats converter command line tool
    - inspect the metadata in python of those files 
    - extract the voxel calibration of those files in python
- create a 3D numpy array in python
    - save it as a TIFF with some made-up voxel calibration
    - open it with all of the below methods and check the the calibration is correct
        - ImageJ > File Open
        - ImageJ > Bio-Formats Importer

What do you think?