### PR TITLE
Tool Installation Fix Links

### DIFF
--- a/_includes/tool_installation/install_skimage_napari_BAND.md
+++ b/_includes/tool_installation/install_skimage_napari_BAND.md
@@ -50,11 +50,11 @@
 
 To execute the below steps you need to open a terminal window:
 
-![terminal](/figures/BAND_Terminal.png)
+![terminal](https://github.com/NEUBIAS/training-resources/raw/master/figures/BAND_Terminal.png)
 
 ...and you also need to open an Application:
 
-![applications](/figures/BAND_applications.png)
+![applications](https://github.com/NEUBIAS/training-resources/raw/master/figures/BAND_applications.png)
 
 
 1. Open a Terminal and execute


### PR DESCRIPTION
I fixed some stuff in the BAND tool installation part.
1. The images were not rendering on the main website. 
From the figure panel the link is  `https://neubias.github.io/training-resources/figures/tool_installation.png`
From the activity the link points to  `https://neubias.github.io/figures/BAND_Terminal.png`
I now included the full link as we normally use for image_data. This should work fine. 

2. fixed the command of wget so that you can copy paste.  