### PR TITLE
Added tests for python scripts in _includes

### DIFF
--- a/.github/workflows/test-python-scripts.yml
+++ b/.github/workflows/test-python-scripts.yml
@@ -1,0 +1,44 @@
+name: test-python-scripts
+
+on:
+  push:
+    branches:
+      - gh-pages
+      - master
+  pull_request: []
+
+jobs:
+  test-python-scripts:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: install xvfb/deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yy mesa-utils libgl1-mesa-dev xvfb curl
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          activate-environment: ""
+          channel-priority: strict
+          miniforge-version: latest
+      - name: install common conda dependencies
+        run: conda install -c conda-forge -c euro-bioimaging python=3.10 napari=0.4.17 pytest notebook matplotlib jupytext "scikit-image>=0.20" openijtiff -y
+      - name: linux test
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash -l {0}
+        run: xvfb-run --server-args="-screen 0 1024x768x24" pytest -v test_python
+      - name: osx test
+        if: matrix.os == 'macos-latest'
+        shell: bash -l {0}
+        run: pytest -v test_python
+      - name: windows test
+        if: matrix.os == 'windows-latest'
+        shell: cmd /C CALL {0}
+        run: pytest -v test_python

--- a/_includes/commenting/activities/binarization_skimage_napari.py
+++ b/_includes/commenting/activities/binarization_skimage_napari.py
@@ -1,10 +1,9 @@
-import numpy as np
 import matplotlib.pyplot as plt
-from skimage import io
+from OpenIJTIFF import open_ij_tiff
 
 # load the image from file
-image_file = "/image_data/xy_8bit__two_cells.tif"
-image = io.imread(image_file)
+image_file = "https://github.com/NEUBIAS/training-resources/raw/master/image_data/xy_8bit__two_cells.tif"
+image, _, _, _ = open_ij_tiff(image_file)
 
 # binarize the image, so that all values larger than the threshold are foreground
 threshold_value = 60

--- a/_includes/filter_morphological/filter_morphological_act1_skimage_napari.py
+++ b/_includes/filter_morphological/filter_morphological_act1_skimage_napari.py
@@ -34,8 +34,8 @@ eroded = erosion(image, footprint = disk(1))
 dilated = dilation(image, footprint = disk(1))
 
 # Add to napari
-napari_viewer.add_labels(eroded, name='eroded1', colormap='magenta', opacity = 0.7)
-napari_viewer.add_labels(dilated, name='dilated1', colormap = 'green', opacity = 0.7)
+napari_viewer.add_image(eroded, name='eroded1', colormap='magenta', opacity = 0.7)
+napari_viewer.add_image(dilated, name='dilated1', colormap='green', opacity = 0.7)
 
 # %% [markdown]
 # Appreciate that the single pixel disappeared with erosion.\

--- a/_includes/spatial_calibration/spatial_calibration_act2_skimage_napari.py
+++ b/_includes/spatial_calibration/spatial_calibration_act2_skimage_napari.py
@@ -5,6 +5,7 @@
 
 # %%
 # Import python packages.
+import os
 from OpenIJTIFF import open_ij_tiff, save_ij_tiff
 import numpy as np
 from napari.viewer import Viewer
@@ -62,7 +63,8 @@ napari_viewer.add_image(image_3D, scale=voxel_size_image_3D, name='image_3D')
 # %%
 # Save the 3D image with the calibration metadata
 save_ij_tiff(
-    '/Users/tischer/Desktop/image_3D_calibrated.tif',
+     # during trainings this Path should be replaced by the user's desktop, e.g. C:/Users/dominik/Desktop
+     os.path.join(os.path.expanduser("~"), "image_3D_calibrated.tif"),
      image_3D,
      axes_image_3D,
      voxel_size_image_3D,

--- a/_includes/string_concat/activities/string_concat_python.py
+++ b/_includes/string_concat/activities/string_concat_python.py
@@ -2,12 +2,12 @@
 #Please note that in Python, unlike imageJ macro language you cannot concatenate strings directly with numbers.
 
 
-text1 = "Hello ";
-text2 = "user number ";
-Text3 = "50"
+text1 = "Hello "
+text2 = "user number "
+text3 = "50"
 
 #concatenating strings
-text3 = text1 + text2 + text3;
+text3 = text1 + text2 + text3
 
 #printing the results
-print(text3);
+print(text3)

--- a/test_python/test_all.py
+++ b/test_python/test_all.py
@@ -2,7 +2,7 @@ import pathlib
 import runpy
 import pytest
 
-scripts = map(str, (pathlib.Path(__file__).parent / '..'/ '_includes').resolve().glob('**/*.py'))
+scripts = filter(lambda x: "jython" not in x.lower(), map(str, (pathlib.Path(__file__).parent / '..'/ '_includes').resolve().glob('**/*.py')))
 
 
 @pytest.mark.parametrize('script', scripts)

--- a/test_python/test_all.py
+++ b/test_python/test_all.py
@@ -1,0 +1,10 @@
+import pathlib
+import runpy
+import pytest
+
+scripts = map(str, (pathlib.Path(__file__).parent / '..'/ '_includes').resolve().glob('**/*.py'))
+
+
+@pytest.mark.parametrize('script', scripts)
+def test_script_execution(script):
+    runpy.run_path(script)

--- a/test_python/test_all.py
+++ b/test_python/test_all.py
@@ -1,10 +1,23 @@
 import pathlib
 import runpy
+
 import pytest
 
-scripts = filter(lambda x: "jython" not in x.lower(), map(str, (pathlib.Path(__file__).parent / '..'/ '_includes').resolve().glob('**/*.py')))
+scripts = filter(
+    lambda x: "jython" not in x.lower(),
+    map(lambda x: x.as_posix(), (pathlib.Path(__file__).parent / ".." / "_includes").resolve().glob("**/*.py")),
+)
 
 
-@pytest.mark.parametrize('script', scripts)
+known_failures = {
+    "measure_intensities_act1_skimage_napari.py": "Requires manual interaction to pass.",
+    "spatial_calibration_act1_skimage_napari.py": "Requires manual interaction to pass.",
+    "volume_slicing_act1_python-napari.py": "Not supposed to be run in a script, but in the napari viewer itself.",
+}
+
+
+@pytest.mark.parametrize("script", scripts)
 def test_script_execution(script):
+    if (script_name := pathlib.Path(script).name) in known_failures:
+        pytest.xfail(known_failures[script_name])
     runpy.run_path(script)


### PR DESCRIPTION
Added some _minimal_ testing of the python activities. Minimal in the sense that the output is not checked - if they have exit status 0, it's counted as success. But it was not a fruitless effort - the following scripts had errors:

* `binarization_skimage_napari.py`: Assumed non-existing local file. Use `OpenIJTIFF` to open image from
  the internet.
* `filter_morphological_ac1_skimage_napari.py`: Used `add_labels` for showing result of morphological operation, with a colormap (colormap is not available for label layers). Changed to `add_image` for both instances after morphological operations.
* `sptial_calibration_act2_skimage_napari.py`: write to _generic_ home folder for testing -  added note for trainings - should be replaced by users Desktop folder (there was a hard-coded folder).
* `string_concat_python.py`: remove semi-colons, fix typo.

the following scripts are expected to fail when ran without interaction:

* `measure_intensities_act1_skimage_napari.py`: Requires manual interaction in napari to pass.
* `spatial_calibration_act1_skimage_napari.py`: Requires manual interaction in napari to pass.
* `volume_slicing_act1_python-napari.py`: Not supposed to be run in a script, but in the napari viewer itself.

I think we could add to this in the future and check some of the outputs - but for now I'd say this is ready to be reviewed/merged.
