### PR TITLE
fix windows ci

### DIFF
--- a/.github/workflows/test-python-scripts.yml
+++ b/.github/workflows/test-python-scripts.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install -yy mesa-utils libgl1-mesa-dev xvfb curl
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-update-conda: true
+          auto-update-conda: false
           auto-activate-base: true
           activate-environment: ""
           channel-priority: strict


### PR DESCRIPTION
A recent bug in conda causes different activation behavior, as it seems. This must be a bug in conda `24.4.0` as the `24.3.0` that is shipped with the current installer still works as expected. I turned off autoupdate of conda for now.

Couldn't find the root cause or concrete change yet, that triggered this behavior.